### PR TITLE
BUGFIX: AssetEditor options

### DIFF
--- a/NodeTypes.Schema.json
+++ b/NodeTypes.Schema.json
@@ -219,17 +219,22 @@
                                 "placeholder": {
                                     "$ref": "#/definitions/label"
                                 },
-                                "multiple": {
-                                    "type": "boolean",
-                                    "default": true
-                                },
-                                "imagesOnly": {
-                                    "type": "boolean",
-                                    "default": false
-                                },
                                 "disabled": {
                                     "type": "boolean",
                                     "default": false
+                                },
+                                "constraints": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "mediaTypes": {
+                                            "type": "array",
+                                            "uniqueItems": true,
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 },
                                 "features": {
                                     "type": "object",

--- a/examples/NodeTypes.Editors.yaml
+++ b/examples/NodeTypes.Editors.yaml
@@ -87,8 +87,6 @@ My.Vendor:Content.Editors:
           editor: 'Neos.Neos/Inspector/Editors/AssetEditor'
           editorOptions:
             placeholder: i18n
-            multiple: false
-            imagesOnly: false
             disabled: false
             features:
               upload: true
@@ -101,8 +99,6 @@ My.Vendor:Content.Editors:
           editor: 'Neos.Neos/Inspector/Editors/AssetEditor'
           editorOptions:
             placeholder: i18n
-            multiple: true
-            imagesOnly: false
             disabled: false
             features:
               upload: true


### PR DESCRIPTION
Allow "constraints" option and remove "multiple" and "imagesOnly".

"multiple" is used only internally?! Seems to not even work if you set this to false and the editor is of type array.

"imagesOnly" only used internally?!