### PR TITLE
TASK: Add missing Property "forceCrop"

### DIFF
--- a/NodeTypes.Schema.json
+++ b/NodeTypes.Schema.json
@@ -434,6 +434,10 @@
                                                     "type": "boolean",
                                                     "default": true
                                                 },
+                                                "forceCrop": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                },
                                                 "locked": {
                                                     "type": "object",
                                                     "additionalProperties": false,


### PR DESCRIPTION
"forceCrop" is missing in the ImageEditor Definitions.

The definition is outlined here: [Neos Docs](https://neos.readthedocs.io/en/stable/References/PropertyEditorReference.html?highlight=forceCrop#property-type-image-neos-media-domain-model-imageinterface-imageeditor-image-selection-upload-editor)