### PR TITLE
TASK: allow for leading slashes in route patterns

### DIFF
--- a/Routes.Schema.json
+++ b/Routes.Schema.json
@@ -30,8 +30,7 @@
                         "my/demo(/{@action}.html)",
                         "products/list/{sortOrder}.{@format}",
                         "demo/<DemoSubroutes>"
-                    ],
-                    "pattern": "^(?!/).*"
+                    ]
                 },
                 "defaults": {
                     "type": "object",

--- a/examples/Routes.Prefixed.yaml
+++ b/examples/Routes.Prefixed.yaml
@@ -1,0 +1,7 @@
+-
+  name: list
+  uriPattern: ''
+-
+  name: details
+  uriPattern: '/{entity}'
+

--- a/examples/Routes.yaml
+++ b/examples/Routes.yaml
@@ -49,3 +49,12 @@
   httpMethods:
     - DELETE
     - EXAMPLE
+
+-
+  name: 'Prefixed subroutes'
+  uriPattern: 'prefixed<Subroutes>'
+  subRoutes:
+    SubRoutes:
+      package: My.Package
+      suffix: Prefixed
+


### PR DESCRIPTION
After working more with sub-routes as illustrated in the added example, it seems the initial pattern restriction is too strict:

When a route is included as sub-route, i.e. the uriPattern is not really at the start of the actual pattern, the limitation against leading slashes does not apply.

It seems routes can't end in a slash, so `prefix/<SubRoutes>` would not allow an empty "sub-pattern", e.g. to list all items of a type in contrary to non-empty "sub-patterns" to interact with specific items.
The alternatives I see are
* moving the `prefix` into the sub-routes, where it would need to be repeated for every route
* defining `prefix` and `prefix/<SubRoutes>` in the "main" config