### PR TITLE
BUGFIX: Image editor option `maximumFileSize` allows string value

### DIFF
--- a/NodeTypes.Schema.json
+++ b/NodeTypes.Schema.json
@@ -391,6 +391,7 @@
                                 "maximumFileSize": {
                                     "type": [
                                         "integer",
+                                        "string",
                                         "null"
                                     ],
                                     "default": null


### PR DESCRIPTION
This option supports string values similar to the `post_max_size` and `upload_max_filesize` options of php.ini, e.g. "1MB". See the "ImageEditor" section of the official Neos 7.3 Property Editor Reference.