### PR TITLE
Allow capital letters for childNode names

### DIFF
--- a/NodeTypes.Schema.json
+++ b/NodeTypes.Schema.json
@@ -1164,7 +1164,7 @@
                     "null"
                 ],
                 "propertyNames": {
-                    "pattern": "^[a-z0-9\\-]+$"
+                    "pattern": "^[a-zA-Z0-9\\-]+$"
                 },
                 "additionalProperties": {
                     "type": [


### PR DESCRIPTION
According to the [Neos documentation](https://neos.readthedocs.io/en/stable/References/NodeTypeDefinition.html#:~:text=%27*%27%3A%20false-,childNodes,-A%20list%20of) this should be fine:

```
childNodes:
  someChild:
    type: 'Neos.Neos:ContentCollection'
```

Currently only lower case letters are allowed in the schema. This change will also allow capital letters.

I don't know if we must disallow the first letter to be capitalised. Feel free to adjust or request changes.